### PR TITLE
Supporting methods without Retry

### DIFF
--- a/atlas-appium/src/main/java/io/qameta/atlas/appium/AppiumDriverConfiguration.java
+++ b/atlas-appium/src/main/java/io/qameta/atlas/appium/AppiumDriverConfiguration.java
@@ -2,21 +2,12 @@ package io.qameta.atlas.appium;
 
 import io.appium.java_client.AppiumDriver;
 import io.qameta.atlas.appium.context.AppiumDriverContext;
-import io.qameta.atlas.appium.extension.AppiumDriverProviderExtension;
-import io.qameta.atlas.appium.extension.AppiumFindByExtension;
-import io.qameta.atlas.appium.extension.LongPressExtension;
-import io.qameta.atlas.appium.extension.SwipeDownOnExtension;
-import io.qameta.atlas.appium.extension.SwipeUpOnExtension;
+import io.qameta.atlas.appium.extension.*;
 import io.qameta.atlas.core.context.RetryerContext;
 import io.qameta.atlas.core.internal.Configuration;
 import io.qameta.atlas.core.internal.DefaultMethodExtension;
 import io.qameta.atlas.core.internal.EmptyRetryer;
-import io.qameta.atlas.webdriver.extension.FilterCollectionExtension;
-import io.qameta.atlas.webdriver.extension.FindByCollectionExtension;
-import io.qameta.atlas.webdriver.extension.ShouldMethodExtension;
-import io.qameta.atlas.webdriver.extension.ToStringMethodExtension;
-import io.qameta.atlas.webdriver.extension.WaitUntilMethodExtension;
-import io.qameta.atlas.webdriver.extension.WrappedElementMethodExtension;
+import io.qameta.atlas.webdriver.extension.*;
 
 
 /**
@@ -29,6 +20,7 @@ public class AppiumDriverConfiguration extends Configuration {
         registerContext(new AppiumDriverContext(appiumDriver));
         registerContext(new RetryerContext(new EmptyRetryer()));
         registerExtension(new AppiumDriverProviderExtension());
+        registerExtension(new RetryAnnotationExtension());
         registerExtension(new DefaultMethodExtension());
         registerExtension(new AppiumFindByExtension());
         registerExtension(new ToStringMethodExtension());

--- a/atlas-appium/src/test/java/io/qameta/atlas/appium/AppiumFindByRetrierTest.java
+++ b/atlas-appium/src/test/java/io/qameta/atlas/appium/AppiumFindByRetrierTest.java
@@ -35,7 +35,7 @@ public class AppiumFindByRetrierTest {
      * Parent mobile element.
      */
     private interface ParentElement extends AtlasMobileElement {
-        @Retry(timeout = 1000L)
+        @Retry(timeout = 1000L, polling = 100)
         @AndroidFindBy(xpath = "//div")
         NestedElement child();
     }

--- a/atlas-core/src/main/java/io/qameta/atlas/core/Atlas.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/Atlas.java
@@ -1,10 +1,7 @@
 package io.qameta.atlas.core;
 
-import io.qameta.atlas.core.api.Context;
-import io.qameta.atlas.core.api.Listener;
-import io.qameta.atlas.core.api.MethodExtension;
-import io.qameta.atlas.core.api.MethodInvoker;
-import io.qameta.atlas.core.api.Target;
+import io.qameta.atlas.core.api.*;
+import io.qameta.atlas.core.context.RetryerContext;
 import io.qameta.atlas.core.context.TargetContext;
 import io.qameta.atlas.core.internal.*;
 import io.qameta.atlas.core.target.HardcodedTarget;
@@ -14,6 +11,7 @@ import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.qameta.atlas.core.util.ReflectionUtils.getMethods;
 
@@ -30,6 +28,10 @@ public class Atlas {
 
     public Atlas(final Configuration configuration) {
         this.configuration = configuration;
+        final Optional<RetryerContext> context = this.configuration.getContext(RetryerContext.class);
+        if (!context.isPresent()) {
+            configuration.registerContext(new RetryerContext(new EmptyRetryer()));
+        }
     }
 
     public Atlas listener(final Listener listener) {

--- a/atlas-core/src/main/java/io/qameta/atlas/core/Atlas.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/Atlas.java
@@ -18,6 +18,7 @@ import static io.qameta.atlas.core.util.ReflectionUtils.getMethods;
 /**
  * @author Artem Eroshenko.
  */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class Atlas {
 
     private final Configuration configuration;

--- a/atlas-core/src/main/java/io/qameta/atlas/core/api/Listener.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/api/Listener.java
@@ -8,7 +8,7 @@ import io.qameta.atlas.core.util.MethodInfo;
  */
 public interface Listener extends Extension {
 
-    void beforeMethodCall(MethodInfo methodInfo, Configuration configuration);
+    Configuration beforeMethodCall(MethodInfo methodInfo, Configuration configuration);
 
     void afterMethodCall(MethodInfo methodInfo, Configuration configuration);
 

--- a/atlas-core/src/main/java/io/qameta/atlas/core/api/Retry.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/api/Retry.java
@@ -11,9 +11,9 @@ import java.lang.annotation.RetentionPolicy;
 @java.lang.annotation.Target(ElementType.METHOD)
 public @interface Retry {
 
-    long timeout() default 5000L;
+    long timeout() default -1;
 
-    long polling() default 1000L;
+    long polling() default -1;
 
     Class<? extends Throwable>[] ignoring() default {Throwable.class};
 

--- a/atlas-core/src/main/java/io/qameta/atlas/core/internal/DefaultRetryer.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/internal/DefaultRetryer.java
@@ -1,49 +1,27 @@
 package io.qameta.atlas.core.internal;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.Set;
+
 
 /**
- * Retryer.
+ * @deprecated
+ * class constructor will be removed in the next release.
+ * Now the default implementation always used from the Atlas context
+ * see reference
  */
-@SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-public class DefaultRetryer implements Retryer {
-
-    private final List<Class<? extends Throwable>> ignoring;
-
-    private final Long start;
-
-    private Long timeout;
-
-    private Long polling;
+@Deprecated
+public class DefaultRetryer extends TimeBasedRetryer {
 
     public DefaultRetryer(final Long timeout, final Long polling, final List<Class<? extends Throwable>> ignoring) {
-        this.ignoring = new ArrayList<>(ignoring);
-        this.start = System.currentTimeMillis();
-        this.timeout = timeout;
-        this.polling = polling;
+        this(timeout, polling, new HashSet<>(ignoring));
     }
 
-    public void ignore(final Class<? extends Throwable> throwable) {
-        this.ignoring.add(throwable);
+    private DefaultRetryer(final Long timeout, final Long polling, final Set<Class<? extends Throwable>> ignoring) {
+        setTimeOut(timeout);
+        setPolling(polling);
+        addAllToIgnore(ignoring);
     }
 
-    public void timeoutInMillis(final Long millis) {
-        this.timeout = millis;
-    }
-
-    @Override
-    public void timeoutInSeconds(final int seconds) {
-        this.timeout = TimeUnit.SECONDS.toMillis(seconds);
-    }
-
-    public void polling(final Long polling) {
-        this.polling = polling;
-    }
-
-    @Override
-    public boolean shouldRetry(final Throwable e) {
-        return shouldRetry(start, timeout, polling, ignoring, e);
-    }
 }

--- a/atlas-core/src/main/java/io/qameta/atlas/core/internal/EmptyRetryer.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/internal/EmptyRetryer.java
@@ -1,35 +1,17 @@
 package io.qameta.atlas.core.internal;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Retryer with default values.
  */
-public class EmptyRetryer implements Retryer {
-
-    private final Long start;
-    private final Long polling;
-    private final List<Class<? extends Throwable>> ignoring;
-    private Long timeout;
+public class EmptyRetryer extends TimeBasedRetryer {
 
     public EmptyRetryer() {
-        this.start = System.currentTimeMillis();
-        this.timeout = 5000L;
-        this.polling = 1000L;
-        this.ignoring = Collections.singletonList(Throwable.class);
-    }
-
-    @Override
-    public boolean shouldRetry(final Throwable e) {
-        return shouldRetry(start, timeout, polling, ignoring, e);
-
-    }
-
-    @Override
-    public void timeoutInSeconds(final int seconds) {
-        this.timeout = TimeUnit.SECONDS.toMillis(seconds);
+        setTimeOutInSeconds(5);
+        setPolling(1000);
+        addAllToIgnore(Stream.of(Throwable.class).collect(Collectors.toSet()));
     }
 
 }

--- a/atlas-core/src/main/java/io/qameta/atlas/core/internal/ListenerNotifier.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/internal/ListenerNotifier.java
@@ -23,14 +23,15 @@ public class ListenerNotifier implements Listener {
     }
 
     @Override
-    public void beforeMethodCall(final MethodInfo methodInfo, final Configuration configuration) {
+    public Configuration beforeMethodCall(final MethodInfo methodInfo, final Configuration configuration) {
         for (Listener listener : listeners) {
             try {
-                listener.beforeMethodCall(methodInfo, configuration);
+                return listener.beforeMethodCall(methodInfo, configuration);
             } catch (Exception e) {
                 LOGGER.error("Error during listener {} beforeMethodCall", listener, e);
             }
         }
+        return configuration;
     }
 
     @Override

--- a/atlas-core/src/main/java/io/qameta/atlas/core/internal/Retryer.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/internal/Retryer.java
@@ -1,28 +1,12 @@
 package io.qameta.atlas.core.internal;
 
-import java.util.List;
+import io.qameta.atlas.core.util.MethodInfo;
 
 /**
  * Retryer.
  */
 public interface Retryer {
 
-    boolean shouldRetry(Throwable e) throws Throwable;
-
-    default boolean shouldRetry(final Long start, final Long timeout, final Long polling,
-                                final List<Class<? extends Throwable>> ignoring, final Throwable e) {
-        final long current = System.currentTimeMillis();
-        if (!(ignoring.stream().anyMatch(clazz -> clazz.isInstance(e)) && start + timeout < current)) {
-            try {
-                Thread.sleep(polling);
-                return true;
-            } catch (InterruptedException i) {
-                Thread.currentThread().interrupt();
-            }
-        }
-        return false;
-    }
-
-    void timeoutInSeconds(int seconds);
+    boolean shouldRetry(Throwable e, MethodInfo methodInfo) throws Throwable;
 
 }

--- a/atlas-core/src/main/java/io/qameta/atlas/core/internal/TimeBasedRetryer.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/internal/TimeBasedRetryer.java
@@ -1,0 +1,70 @@
+package io.qameta.atlas.core.internal;
+
+import io.qameta.atlas.core.util.MethodInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Default Retryer based on timeout.
+ */
+public abstract class TimeBasedRetryer implements Retryer {
+
+    private final Set<Class<? extends Throwable>> ignoring = new HashSet<>();
+    private final Long start = System.currentTimeMillis();
+    private Long timeout = 0L;
+    private Long polling = 0L;
+
+    @Override
+    public boolean shouldRetry(final Throwable e, final MethodInfo methodInfo) {
+        return shouldRetry(start, e);
+    }
+
+    public boolean shouldRetry(final Long start, final Throwable e) {
+        return shouldRetry(start, getTimeout(), getPolling(), getIgnoring(), e);
+    }
+
+    public boolean shouldRetry(final Long start, final Long timeout, final Long polling,
+                        final Set<Class<? extends Throwable>> ignoring, final Throwable e) {
+        final long current = System.currentTimeMillis();
+        if (!(ignoring.stream().anyMatch(clazz -> clazz.isInstance(e)) && start + timeout < current)) {
+            try {
+                Thread.sleep(polling);
+                return true;
+            } catch (InterruptedException i) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return false;
+    }
+
+    public void setTimeOutInSeconds(final int seconds) {
+        setTimeOut(TimeUnit.SECONDS.toMillis(seconds));
+    }
+
+    public void setTimeOut(final long ms) {
+        this.timeout = ms;
+    }
+
+    public long getTimeout() {
+        return this.timeout;
+    }
+
+    public long getPolling() {
+        return polling;
+    }
+
+    public void setPolling(final long ms) {
+        this.polling = ms;
+    }
+
+    public Set<Class<? extends Throwable>> getIgnoring() {
+        return ignoring;
+    }
+
+    public void addAllToIgnore(final Set<Class<? extends Throwable>> toIgnoring) {
+        ignoring.addAll(toIgnoring);
+    }
+
+}

--- a/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/AtlasWebElement.java
+++ b/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/AtlasWebElement.java
@@ -170,4 +170,20 @@ public interface AtlasWebElement<T extends WebElement> extends WrapsElement, Web
      */
     Object executeScript(String script);
 
+
+    /**
+     * This method handled by the {@link io.qameta.atlas.webdriver.extension.IsExtension}.
+     */
+    boolean exists();
+
+    /**
+     * This method handled by the {@link io.qameta.atlas.webdriver.extension.IsExtension}.
+     */
+    boolean is(Matcher matcher);
+
+    /**
+     * This method handled by the {@link io.qameta.atlas.webdriver.extension.IsExtension}.
+     */
+    boolean isNot(Matcher matcher);
+
 }

--- a/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/WebDriverConfiguration.java
+++ b/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/WebDriverConfiguration.java
@@ -1,20 +1,11 @@
 package io.qameta.atlas.webdriver;
 
 import io.qameta.atlas.core.context.RetryerContext;
-import io.qameta.atlas.core.internal.EmptyRetryer;
-import io.qameta.atlas.webdriver.context.WebDriverContext;
 import io.qameta.atlas.core.internal.Configuration;
 import io.qameta.atlas.core.internal.DefaultMethodExtension;
-import io.qameta.atlas.webdriver.extension.DriverProviderExtension;
-import io.qameta.atlas.webdriver.extension.ExecuteJScriptMethodExtension;
-import io.qameta.atlas.webdriver.extension.FilterCollectionExtension;
-import io.qameta.atlas.webdriver.extension.FindByCollectionExtension;
-import io.qameta.atlas.webdriver.extension.FindByExtension;
-import io.qameta.atlas.webdriver.extension.PageExtension;
-import io.qameta.atlas.webdriver.extension.ShouldMethodExtension;
-import io.qameta.atlas.webdriver.extension.ToStringMethodExtension;
-import io.qameta.atlas.webdriver.extension.WaitUntilMethodExtension;
-import io.qameta.atlas.webdriver.extension.WrappedElementMethodExtension;
+import io.qameta.atlas.core.internal.EmptyRetryer;
+import io.qameta.atlas.webdriver.context.WebDriverContext;
+import io.qameta.atlas.webdriver.extension.*;
 import org.openqa.selenium.WebDriver;
 
 /**
@@ -26,6 +17,7 @@ public class WebDriverConfiguration extends Configuration {
     public WebDriverConfiguration(final WebDriver webDriver) {
         registerContext(new WebDriverContext(webDriver));
         registerContext(new RetryerContext(new EmptyRetryer()));
+        registerExtension(new RetryAnnotationExtension());
         registerExtension(new DriverProviderExtension());
         registerExtension(new DefaultMethodExtension());
         registerExtension(new FindByExtension());

--- a/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/extension/IsExtension.java
+++ b/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/extension/IsExtension.java
@@ -1,0 +1,147 @@
+package io.qameta.atlas.webdriver.extension;
+
+import io.qameta.atlas.core.Atlas;
+import io.qameta.atlas.core.api.MethodExtension;
+import io.qameta.atlas.core.context.RetryerContext;
+import io.qameta.atlas.core.context.TargetContext;
+import io.qameta.atlas.core.internal.Configuration;
+import io.qameta.atlas.core.internal.Retryer;
+import io.qameta.atlas.core.internal.TimeBasedRetryer;
+import io.qameta.atlas.core.util.MethodInfo;
+import org.hamcrest.Matcher;
+import org.openqa.selenium.*;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Extension for momentary checking atlas web elements.
+ */
+public class IsExtension implements MethodExtension {
+
+    private final Set<Class<? extends Throwable>> requiredToIgnoring;
+
+    public IsExtension() {
+        this(NotFoundException.class, NoSuchElementException.class, StaleElementReferenceException.class);
+    }
+
+    @SafeVarargs private IsExtension(final Class<? extends Throwable>... requiredToIgnor) {
+        requiredToIgnoring = Stream.of(requiredToIgnor).collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean test(final Method method) {
+        return getDelegate(method) != null && method.getDeclaringClass().isAssignableFrom(WebElement.class);
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final MethodInfo methodInfo, final Configuration configuration) {
+        assert proxy instanceof SearchContext;
+        final Retryer retryer = configuration.requireContext(RetryerContext.class).getValue();
+        if (retryer instanceof TimeBasedRetryer) {
+            final TimeBasedRetryer timeBasedRetryer = (TimeBasedRetryer) retryer;
+            final boolean suppressThrowable = suppressThrowable(timeBasedRetryer, requiredToIgnoring);
+            if (suppressThrowable) {
+                final Configuration child = configuration.child();
+                child.registerContext(new RetryerContext(retryer));
+                return new Atlas(child).create(proxy, Boolean.class);
+            }
+        }
+
+        final Delegate delegate = getDelegate(methodInfo.getMethod());
+        final TargetContext targetContext = configuration.requireContext(TargetContext.class);
+        final boolean result;
+        switch (delegate) {
+            case exists:
+                result = exist(targetContext);
+                break;
+            case isDisplayed:
+                result = isDisplayed(targetContext);
+                break;
+            case is:
+                result = matching(proxy, methodInfo, false);
+                break;
+            case isNot:
+                result = matching(proxy, methodInfo, true);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected delegate value: " + delegate);
+        }
+        return result;
+    }
+
+    @SuppressWarnings("PMD.IdenticalCatchBranches")
+    private Boolean isDisplayed(final TargetContext targetContext) {
+        boolean result;
+        try {
+            result = ((WebElement) targetContext.getValue().instance()).isDisplayed();
+        } catch (StaleElementReferenceException e) {
+            result = false;
+        } catch (NoSuchElementException e) {
+            result = true;
+        }
+        return result;
+    }
+
+    private Boolean exist(final TargetContext targetContext) {
+        boolean result;
+        try {
+            final WebElement webElement = (WebElement) targetContext.getValue().instance();
+            webElement.isDisplayed();
+            result = true;
+        } catch (NoSuchElementException | StaleElementReferenceException e) {
+            result = false;
+        }
+        return result;
+    }
+
+
+    /**
+     * Add throwable suppressor, for skip reTry timeouts in all nested calls.
+     */
+    private boolean suppressThrowable(final TimeBasedRetryer retryer, final Set<Class<? extends Throwable>> classes) {
+        final Set<Class<? extends Throwable>> ignoring = retryer.getIgnoring();
+        boolean override = false;
+        for (Class<? extends Throwable> requiredToIgnore : classes) {
+            if (!ignoring.contains(requiredToIgnore)) {
+                override = true;
+                ignoring.add(requiredToIgnore);
+            }
+        }
+        return override;
+    }
+
+    private boolean matching(final Object proxy, final MethodInfo methodInfo, final boolean reverse) {
+        final Matcher matcher = methodInfo
+                .getParameter(Matcher.class)
+                .orElseThrow(() -> new IllegalStateException("Unexpected method signature"));
+        return reverse != matcher.matches(proxy);
+    }
+
+    /**
+     * Check delegate names and check [boolean] return type.
+     */
+    private Delegate getDelegate(final Method method) {
+        return
+                Arrays.stream(Delegate.values())
+                        .filter(value -> method.getName().equals(value.name())).findFirst()
+                        .filter(delegate -> method.getReturnType().isAssignableFrom(Boolean.class))
+                        .orElse(null);
+    }
+
+    /**
+     * Methods names for interception.
+     */
+    @SuppressWarnings("PMD")
+    enum Delegate {
+        exists,
+        isDisplayed,
+        is,
+        isNot
+    }
+
+}
+

--- a/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/extension/RetryAnnotationExtension.java
+++ b/atlas-webdriver/src/main/java/io/qameta/atlas/webdriver/extension/RetryAnnotationExtension.java
@@ -1,0 +1,51 @@
+package io.qameta.atlas.webdriver.extension;
+
+import io.qameta.atlas.core.Atlas;
+import io.qameta.atlas.core.api.MethodExtension;
+import io.qameta.atlas.core.api.Retry;
+import io.qameta.atlas.core.context.RetryerContext;
+import io.qameta.atlas.core.internal.Configuration;
+import io.qameta.atlas.core.internal.Retryer;
+import io.qameta.atlas.core.internal.TimeBasedRetryer;
+import io.qameta.atlas.core.util.MethodInfo;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Extension for pre-processing @Retry annotations.
+ */
+public class RetryAnnotationExtension implements MethodExtension {
+
+    @Override
+    public boolean test(final Method method) {
+        return Optional.ofNullable(method.getAnnotation(Retry.class)).isPresent();
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final MethodInfo methodInfo, final Configuration configuration) {
+        final Retry retry = methodInfo.getMethod().getAnnotation(Retry.class);
+        assert retry != null : "@Retry annotation can't be null";
+        final Retryer retryer = configuration.requireContext(RetryerContext.class).getValue();
+        if (retryer instanceof TimeBasedRetryer) {
+            final TimeBasedRetryer timeBasedRetryer = (TimeBasedRetryer) retryer;
+            final long timeout = retry.timeout();
+            if (timeout >= 0) {
+                timeBasedRetryer.setTimeOut(timeout);
+            }
+            final long polling = retry.polling();
+            if (polling >= 0) {
+                timeBasedRetryer.setPolling(polling);
+            }
+            timeBasedRetryer.addAllToIgnore(Stream.of(retry.ignoring()).collect(Collectors.toSet()));
+            final Configuration child = configuration.child();
+            child.registerContext(new RetryerContext(retryer));
+            return new Atlas(child).create(proxy, methodInfo.getMethod().getReturnType());
+        } else {
+            return new Atlas(configuration).create(proxy, methodInfo.getMethod().getReturnType());
+        }
+    }
+
+}

--- a/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/ElementsCollectionTest.java
+++ b/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/ElementsCollectionTest.java
@@ -1,6 +1,8 @@
 package io.qameta.atlas.webdriver;
 
 import io.qameta.atlas.core.Atlas;
+import io.qameta.atlas.core.context.RetryerContext;
+import io.qameta.atlas.core.internal.EmptyRetryer;
 import io.qameta.atlas.webdriver.extension.FindBy;
 import io.qameta.atlas.webdriver.extension.FindByCollectionExtension;
 import org.junit.Before;
@@ -42,6 +44,7 @@ public class ElementsCollectionTest {
         when(collection.size()).thenReturn(DEFAULT_SIZE);
 
         ParentElement parentElement = new Atlas()
+                .context(new RetryerContext(new EmptyRetryer()))
                 .extension(new FindByCollectionExtension())
                 .create(parent, ParentElement.class);
 
@@ -54,6 +57,7 @@ public class ElementsCollectionTest {
         when(collection.size()).thenReturn(DEFAULT_SIZE);
 
         ParentElement parentElement = new Atlas()
+                .context(new RetryerContext(new EmptyRetryer()))
                 .extension(new FindByCollectionExtension())
                 .create(parent, ParentElement.class);
 
@@ -73,6 +77,7 @@ public class ElementsCollectionTest {
         when(block.isDisplayed()).thenReturn(true);
 
         ParentElement parentElement = new Atlas(new WebDriverConfiguration(mock(WebDriver.class)))
+                .context(new RetryerContext(new EmptyRetryer()))
                 .create(parent, ParentElement.class);
 
         ListElement element = parentElement.collection().get(0);
@@ -90,6 +95,7 @@ public class ElementsCollectionTest {
             return new ArrayList<>();
         });
         ParentElement parentElement = new Atlas(new WebDriverConfiguration(mock(WebDriver.class)))
+                .context(new RetryerContext(new EmptyRetryer()))
                 .create(parent, ParentElement.class);
         parentElement.collection()
                 .should(hasSize(1));

--- a/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/IsExtensionTest.java
+++ b/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/IsExtensionTest.java
@@ -1,0 +1,33 @@
+package io.qameta.atlas.webdriver;
+
+import io.qameta.atlas.core.Atlas;
+import io.qameta.atlas.webdriver.extension.IsExtension;
+import io.qameta.atlas.webdriver.extension.RetryAnnotationExtension;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NotFoundException;
+import org.openqa.selenium.WebElement;
+
+import static io.qameta.atlas.webdriver.testdata.ObjectFactory.mockAtlasWebElement;
+import static io.qameta.atlas.webdriver.testdata.ObjectFactory.mockWebDriver;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class IsExtensionTest {
+
+    @Test
+    public void noWaitForNestedSearch() {
+        WebElement webElement = mockAtlasWebElement();
+        when(webElement.findElement(By.xpath("//div"))).thenThrow(new NotFoundException());
+
+        Atlas atlas = new Atlas(new WebDriverConfiguration(mockWebDriver()));
+        atlas.extension(new RetryAnnotationExtension());
+        atlas.extension(new IsExtension());
+        final WebElement element = atlas.create(webElement, WebElement.class);
+
+        assertThat(element.isDisplayed()).describedAs("Element should not visible").isFalse();
+        verify(webElement, times(1)).isDisplayed();
+        verify(webElement, timeout(0)).isDisplayed();
+    }
+
+}

--- a/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/ShouldExtensionTest.java
+++ b/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/ShouldExtensionTest.java
@@ -109,8 +109,7 @@ public class ShouldExtensionTest {
 
     @SuppressWarnings("unchecked")
     private static ElementsCollection<AtlasWebElement> createElementsCollection(AtlasWebElement... elements) {
-        List target = new ArrayList();
-        target.addAll(asList(elements));
+        List target = new ArrayList(asList(elements));
         return new Atlas()
                 .extension(new ShouldMethodExtension())
                 .create(target, ElementsCollection.class);

--- a/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/WaitUntilExtensionTest.java
+++ b/atlas-webdriver/src/test/java/io/qameta/atlas/webdriver/WaitUntilExtensionTest.java
@@ -96,8 +96,7 @@ public class WaitUntilExtensionTest {
 
     @SuppressWarnings("unchecked")
     private static ElementsCollection<AtlasWebElement> createElementsCollection(AtlasWebElement... elements) {
-        List target = new ArrayList();
-        target.addAll(asList(elements));
+        List target = new ArrayList(asList(elements));
         return new Atlas()
                 .extension(new WaitUntilMethodExtension())
                 .create(target, ElementsCollection.class);


### PR DESCRIPTION
Features:
now RetryerContext is mandatory and should be injected to atlas config
Re-designed Retryer's, now we use global RetryerContext for getting the default behavior
ISExtension (for momentary checking)
now beforeMethod return configuration instance for alteration

fixes:
#81
#79
#74