### PR TITLE
Fix issue with NoSuchElement error when trying to execute default int…

### DIFF
--- a/atlas-core/src/main/java/io/qameta/atlas/core/internal/DefaultMethodExtension.java
+++ b/atlas-core/src/main/java/io/qameta/atlas/core/internal/DefaultMethodExtension.java
@@ -2,8 +2,11 @@ package io.qameta.atlas.core.internal;
 
 import io.qameta.atlas.core.api.MethodExtension;
 import io.qameta.atlas.core.util.MethodInfo;
+import org.apache.commons.lang3.SystemUtils;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
@@ -20,12 +23,43 @@ public class DefaultMethodExtension implements MethodExtension {
     @Override
     public Object invoke(final Object proxy, final MethodInfo methodInfo, final Configuration config) throws Throwable {
         final Class<?> declaringClass = methodInfo.getMethod().getDeclaringClass();
-        final Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class
-                .getDeclaredConstructor(Class.class, int.class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(declaringClass, MethodHandles.Lookup.PRIVATE)
-                .unreflectSpecial(methodInfo.getMethod(), declaringClass)
+
+        if (isJava8()) {
+            final Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class
+                    .getDeclaredConstructor(Class.class, int.class);
+            constructor.setAccessible(true);
+            return constructor.newInstance(declaringClass, MethodHandles.Lookup.PRIVATE)
+                    .unreflectSpecial(methodInfo.getMethod(), declaringClass)
+                    .bindTo(proxy)
+                    .invokeWithArguments(methodInfo.getArgs());
+        }
+
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+        final MethodHandle methodHandle = lookup.findSpecial(
+                declaringClass,
+                methodInfo.getMethod().getName(),
+                MethodType.methodType(
+                        methodInfo.getMethod().getReturnType(),
+                        methodInfo.getMethod().getParameterTypes()
+                ),
+                declaringClass
+        );
+
+        return methodHandle
                 .bindTo(proxy)
                 .invokeWithArguments(methodInfo.getArgs());
+    }
+
+    private boolean isJava8() {
+        String[] versionElements = SystemUtils.JAVA_SPECIFICATION_VERSION.split("\\.");
+        int discard = Integer.parseInt(versionElements[0]);
+        int version;
+        if (discard == 1) {
+            version = Integer.parseInt(versionElements[1]);
+        } else {
+            version = discard;
+        }
+
+        return version == 8;
     }
 }


### PR DESCRIPTION
It's a fix for an issue: https://github.com/qameta/atlas/issues/104

In Java 9+ version we get `NoSuchElementException` in `io/qameta/atlas/core/internal/DefaultMethodExtension.java:24` since starting from Java 9, the accessibility rules for private members and constructors have changed.

There is another solution with `MethodHandles.privateLookupIn()` method but it won't compile for Java 8, therefore I'm using Lookup.findSpecial() which doesn't work for Java 8, but works good with Java 9+. That's why we need `if` to check the version.